### PR TITLE
New setting DEFAULT_TEST_LABELS

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -50,3 +50,19 @@ does not exist for a given app it will be skipped.
 If you are not using :ref:`CoverageRunner` then you do not need to define this
 setting.
 
+.. _DEFAULT_TEST_LABELS:
+
+DEFAULT_TEST_LABELS
+-----------------------------------
+
+:ref:`DEFAULT_TEST_LABELS` is used by the :ref:`CoverageRunner`. It defines
+the default set of test labels when none are passed in invoking the test
+runner. This allows running tests on the same set of apps, test classes,
+and test methods each time. 
+
+.. code-block:: python
+
+    DEFAULT_TEST_LABELS = ['app1', 'app2.TestClass', 'app3.TestClass.test_method']
+
+If this is set, passing 'all' as the only test label
+on the command line will run all the tests.

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -76,6 +76,23 @@ define a set of submodules to be included in the report using the setting
 Using this setting the test runner will report the coverage of listed submodules of the tested
 apps (if they exist).
 
+If you usually want to pass the same set of test labels when you run tests,
+you can set :ref:`DEFAULT_TEST_LABELS` in your settings.
+
+.. code-block:: python
+
+    DEFAULT_TEST_LABELS = ['app1', 'app2.TestClass', 'app3.TestClass.test_method']
+
+Then `django-admin.py test` will act like
+
+.. code-block:: bash
+
+    django-admin.py test app1 app2.TestClass app3.TestClass.test_method
+
+If you've done that, you can still pass 'all' on the command line to run
+tests as if you had not passed any test labels, e.g.
+`run test all`.
+
 
 .. _ViewTestMixin:
 

--- a/hilbert/test.py
+++ b/hilbert/test.py
@@ -90,6 +90,15 @@ class CoverageRunner(DjangoTestSuiteRunner):
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         run_with_coverage = hasattr(settings, 'COVERAGE_MODULES')
 
+        # Set DEFAULT_TEST_LABELS to run just the tests we want
+        # when we don't give 'test' any arguments
+        if not test_labels:
+            test_labels = getattr(settings, 'DEFAULT_TEST_LABELS', [])
+        # If we've set DEFAULT_TEST_LABELS and we want to run them all,
+        # just say 'test all'
+        elif list(test_labels) == ['all']:
+            test_labels = []
+
         if run_with_coverage:
             import coverage
             coverage.use_cache(0)

--- a/hilbert/tests/__init__.py
+++ b/hilbert/tests/__init__.py
@@ -2,3 +2,4 @@ from hilbert.tests.base import *
 from hilbert.tests.decorators import *
 from hilbert.tests.http import *
 from hilbert.tests.middleware import *
+from hilbert.tests.test import *

--- a/hilbert/tests/test.py
+++ b/hilbert/tests/test.py
@@ -1,0 +1,57 @@
+from hilbert.test import TestCase, CoverageRunner
+from django.test.simple import DjangoTestSuiteRunner
+from django.conf import settings
+
+class TestRunnerTest(TestCase):
+    def do_test(self, default_test_labels_setting, test_labels_passed,
+                expected_test_labels_used):
+
+        # FIXME: this method is ugly. It should be possible to clean it up
+        # using mock if we're willing to add that as a test dependency.
+
+        if default_test_labels_setting is None:
+            if hasattr(settings, 'DEFAULT_TEST_LABELS'):
+                delattr(settings, 'DEFAULT_TEST_LABELS')
+        else:
+            settings.DEFAULT_TEST_LABELS = default_test_labels_setting
+
+        # Avoid all the coverage machinery
+        coverage_modules = settings.COVERAGE_MODULES
+        delattr(settings, 'COVERAGE_MODULES')
+
+        # monkey-patch DjangoTestSuiteRunner, which is what hilbert runner
+        # will invoke
+        def fake_run_tests(self, test_labels, extra_tests, **kwargs):
+            return test_labels
+
+        real_run_tests = DjangoTestSuiteRunner.run_tests
+
+        # Call run_tests. Using our fake run_tests, it should return
+        # whatever hilbert's run_tests passed in as test_labels,
+        # which should be the DEFAULT_TEST_LABELS
+        try:
+            DjangoTestSuiteRunner.run_tests = fake_run_tests
+            runner = CoverageRunner()
+            labels_used = runner.run_tests(test_labels=test_labels_passed)
+        finally:
+            # un-monkey-patch
+            DjangoTestSuiteRunner.run_tests = real_run_tests
+            # restore COVERAGE_MODULES
+            settings.COVERAGE_MODULES = coverage_modules
+        self.assertEqual(labels_used, expected_test_labels_used)
+
+    def test_default_test_labels(self):
+        """If default is set and no tests named on command line, the
+        defaults are used"""
+        self.do_test(['foo', 'bar'], [], ['foo', 'bar'])
+
+    def test_default_test_labels_unset(self):
+        """If default is not set, you get whatever you say on the command line"""
+        self.do_test(None, [], [])
+        self.do_test(None, ['x', 'y'], ['x', 'y'])
+
+
+    def test_default_test_labels_all(self):
+        """If default is set, you can act like it's not by saying 'all'
+        on the command line"""
+        self.do_test(['foo', 'bar'], ['all'], [])


### PR DESCRIPTION
This allows configuration to just run tests by default on our apps (or whatever we want) and not every installed app.
