### PR TITLE
Pass args/kwargs as keyword arguments to reverse

### DIFF
--- a/hilbert/test.py
+++ b/hilbert/test.py
@@ -136,8 +136,8 @@ class ViewTestMixin(object):
 
     def setUp(self):
         super(ViewTestMixin, self).setUp()
-        name, arg, kwargs = self.get_url()
-        self.url = reverse(name, *arg, **kwargs)
+        name, args, kwargs = self.get_url()
+        self.url = reverse(name, args=args, kwargs=kwargs)
 
     def get_url(self):
         name = self.__class__.url_name


### PR DESCRIPTION
args and kwargs are keyword arguments to reverse (https://docs.djangoproject.com/en/1.4/topics/http/urls/#reverse)...I can't see how overriding get_url_args() and get_url_kwargs() can work properly with the code minus this change.
